### PR TITLE
Enable `users` Endpoints

### DIFF
--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::API
+  include RackSessionFix
+
   before_action :configure_permitted_parameters, if: :devise_controller?
 
   protected

--- a/api/app/controllers/application_controller.rb
+++ b/api/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  before_action :configure_permitted_parameters, if: :devise_controller?
+
+  protected
+
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i[name birth_date])
+  end
 end

--- a/api/app/controllers/concerns/rack_session_fix.rb
+++ b/api/app/controllers/concerns/rack_session_fix.rb
@@ -1,0 +1,19 @@
+module RackSessionFix
+  extend ActiveSupport::Concern
+
+  class FakeRackSession < Hash
+    def enabled?
+      false
+    end
+  end
+
+  included do
+    before_action :set_fake_rack_session_for_devise
+
+    private
+
+    def set_fake_rack_session_for_devise
+      request.env['rack.session'] ||= FakeRackSession.new
+    end
+  end
+end


### PR DESCRIPTION
## What & Why
Enable and test user endpoints that will be consume from the Frontend.
In particular, the ones related to Registration and SignIn/Out.

These are the default routes for Users from `devise`:

<img width="1563" alt="Screenshot 2023-08-26 at 3 00 37 PM" src="https://github.com/wyeworks/finder/assets/62676004/e57bf242-3cfd-497c-a2ad-c226ba319ea0">

## Disclaimers
Application was returning a `500 error` after successfully creating a `user`. This is because `devise` tries to authenticate the resource that got created, and when trying to call `authenticate_user!` it failed with the following error:
```
ActionDispatch::Request::Session::DisabledSessionError (Your application has sessions disabled. To write to the session you must first configure a session store)
```
This is apparently a known issue reported [here](https://github.com/heartcombo/devise/issues/5443). 
I used the temporary solution posted [here](https://github.com/heartcombo/devise/issues/5443#issuecomment-1009779292).
There's also an [open PR](https://github.com/heartcombo/devise/pull/5474) on `devise` for fixing it.
If the PR gets merged eventually, this fix/patch won't be necessary anymore.

## How
- [x] Permit required params when using Devise controllers.
- [x] Fix DisabledSessionError from ActionDispatch (see Disclaimers section).
- [x] Test manually with Postman.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Registro Usuario - POST](https://trello.com/c/Ff6M1e12/22-be-registro-usuario-post)

## Postman Screenshots
#### Successful POST request for creating a new `user`
<img width="1355" alt="Screenshot 2023-08-26 at 4 59 46 PM" src="https://github.com/wyeworks/finder/assets/62676004/7e34e1c3-3bf4-436d-b640-ad3db0ed81de">

#### Successful sign_in of the `user`
<img width="1361" alt="Screenshot 2023-08-26 at 5 18 05 PM" src="https://github.com/wyeworks/finder/assets/62676004/96df469c-7339-4f3c-9c09-1fc1e51282a8">

#### Unsuccessful sign_in of the `user`
<img width="1366" alt="Screenshot 2023-08-26 at 5 18 18 PM" src="https://github.com/wyeworks/finder/assets/62676004/aab72f1b-124a-40c2-92f8-951b2634bcc2">
