### PR TITLE
Add workflow for running Rspec and Rubocop + Update Next.js port

### DIFF
--- a/.github/workflows/rails.yml
+++ b/.github/workflows/rails.yml
@@ -1,0 +1,51 @@
+name: RSpec and Rubocop checks
+
+on:
+  # Runs on pushes and pull requests targeting main or develop branches
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  rspec-rubocop:
+    # Set the action to run in the `api` sub directory
+    defaults:
+      run:
+        working-directory: ./api
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: api
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.2.2
+    - name: Install dependencies
+      run: bundle install
+    - name: Setup DB and run RSpec
+      env:
+        RAILS_ENV: test
+        DB_USER: api
+        DB_PASSWORD: postgres
+        PGHOST: localhost
+        PGPORT: 5432
+      run: |
+        bundle exec rails db:create db:migrate
+        bundle exec rspec
+    - name: Run Rubocop
+      run: bundle exec rubocop

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -58,6 +58,8 @@ development:
 test:
   <<: *default
   database: api_test
+  username: <%= ENV["DB_USER"] %>
+  password: <%= ENV["DB_PASSWORD"] %>
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/client/package.json
+++ b/client/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 3333",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 3333",
     "lint": "next lint",
     "prepare": "cd .. && husky install client/.husky",
     "format": "prettier --check --ignore-path .gitignore .",


### PR DESCRIPTION
## What & Why
- Update `Next.js` port from `3000` to `3333`. This is necessary because both Next.js and Rails use the same default port: `3000`.
- Add workflow for running Rspec and Rubocop in the Rails app.
  - Using Github actions.
  - Next application already has its workflow configured.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [Setup Repo - Backend](https://trello.com/c/rYr9tRjO/38-setup-repo-backend)
- [Github Actions with Ruby on Rails post](https://rhtlingayat.medium.com/continuous-integration-with-github-action-rails-db9bac009fa8)