### PR TITLE
Add Email Validation and Password Complexity

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -15,6 +15,9 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Metrics/BlockLength:
+  Enabled: false
+
 Metrics/MethodLength:
   Enabled: false
 

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -4,4 +4,14 @@ class User < ApplicationRecord
 
   # Validations
   validates :name, :birth_date, presence: true
+  validate :password_complexity
+
+  private
+
+  def password_complexity
+    return if password =~ /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-])/
+
+    errors.add :password, 'Complexity requirement not met. ' \
+                          'Please use: 1 uppercase, 1 lowercase, 1 digit and 1 special character'
+  end
 end

--- a/api/config/initializers/devise.rb
+++ b/api/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 8..70
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/api/config/initializers/devise.rb
+++ b/api/config/initializers/devise.rb
@@ -183,7 +183,7 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A[^@\s]+@fing.edu.uy\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/api/spec/factories/user.rb
+++ b/api/spec/factories/user.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :user do
     sequence(:name) { |n| "Name_#{n}" }
     sequence(:email) { |n| "email_#{n}@fing.edu.uy" }
+    password { 'Test#123' }
     birth_date { Date.parse('2023-01-01') }
   end
 end

--- a/api/spec/factories/user.rb
+++ b/api/spec/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
     sequence(:name) { |n| "Name_#{n}" }
-    sequence(:email) { |n| "email_#{n}@mail.com" }
+    sequence(:email) { |n| "email_#{n}@fing.edu.uy" }
     birth_date { Date.parse('2023-01-01') }
   end
 end

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -1,10 +1,24 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  subject { build :user }
-
   describe 'validations' do
     it { should validate_presence_of(:name) }
     it { should validate_presence_of(:birth_date) }
+
+    describe 'email' do
+      let(:subject) { build :user, email: }
+
+      context 'invalid format' do
+        let(:email) { 'test@mail.com' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'valid format' do
+        let(:email) { 'test@fing.edu.uy' }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 end

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -20,5 +20,27 @@ RSpec.describe User, type: :model do
         it { is_expected.to be_valid }
       end
     end
+
+    describe '#password_complexity' do
+      let(:subject) { build :user, password: }
+
+      context 'length requirement not met' do
+        let(:password) { '123' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'complexity requirement not met' do
+        let(:password) { 'password' }
+
+        it { is_expected.not_to be_valid }
+      end
+
+      context 'valid password' do
+        let(:password) { 'Test#123' }
+
+        it { is_expected.to be_valid }
+      end
+    end
   end
 end


### PR DESCRIPTION
## What & Why
Add email format validation to allow users with only the `@fing.edy.uy` domain to be created.

Change password length configuration.
Add password complexity, following [NIST Password Guidelines](https://blog.netwrix.com/2022/11/14/nist-password-guidelines/).

## How
- [x] Add email format validation.
- [x] Add password complexity and length checks.
- [x] Add model tests.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Agregar validación para el email y password complexity](https://trello.com/c/soRaRNg6/53-be-agregar-validaci%C3%B3n-para-el-email-y-password-complexity)
- [rubular - For validating regexs](https://rubular.com/)
- [Manual solution for adding password complexity when using devise](https://github.com/heartcombo/devise/wiki/How-To:-Set-up-simple-password-complexity-requirements#manual-solution)