### PR TITLE
Update Password Complexity Validation

### DIFF
--- a/api/app/controllers/users/registrations_controller.rb
+++ b/api/app/controllers/users/registrations_controller.rb
@@ -21,7 +21,8 @@ module Users
 
         render json: {
           message: "User couldn't be created successfully. " \
-                   "#{current_user.errors.full_messages.to_sentence}"
+                   "#{current_user.errors.full_messages.to_sentence}",
+          errors: current_user.errors.messages
         }, status: :unprocessable_entity
       end
     end

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   private
 
   def password_complexity
-    return if password =~ /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-])/
+    return if password =~ /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-.])/
 
     errors.add :password, 'Complexity requirement not met. ' \
                           'Please use: 1 uppercase, 1 lowercase, 1 digit and 1 special character'

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -36,8 +36,14 @@ RSpec.describe User, type: :model do
         it { is_expected.not_to be_valid }
       end
 
-      context 'valid password' do
+      context 'valid password with # as a special character' do
         let(:password) { 'Test#123' }
+
+        it { is_expected.to be_valid }
+      end
+
+      context 'valid password with . as a special character' do
+        let(:password) { 'Test.123' }
 
         it { is_expected.to be_valid }
       end

--- a/api/spec/requests/users/registrations_controller_spec.rb
+++ b/api/spec/requests/users/registrations_controller_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Users::RegistrationsController, type: :request do
         json_response = response.parsed_body
 
         expect(json_response['message']).to include("User couldn't be created successfully")
+        expect(json_response['errors']['password'][0]).to include('is too short')
+        expect(json_response['errors']['password'][1]).to include('Complexity requirement not met')
       end
     end
   end


### PR DESCRIPTION
## What && Why
Update password complexity validation, adding the dot (`.`) as a special character to the Regex.
This was raised as an issue by the QA team, but it wasn't necessarily a bug, just something that was not originally considered in the regular expression (intentionally).

Returning a hash with the `errors` inside JSON response after `signup`, in addition to the error `message`.
This will be useful for displaying these errors in the FE.

## How
- [x] Update password complexity validation.
- [x] Add unit test for this new scenario.
- [x] Add `errors` hash to JSON response on `signup`.
- [x] Update requests specs.
- [x] Test with Postman.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Actualizar Regex de la validación de la Password](https://trello.com/c/DrOQLsoz/80-be-actualizar-regex-de-la-validaci%C3%B3n-de-la-password)
- ![](https://github.trello.services/images/mini-trello-icon.png) [QA Ticket: Devuelve contraseña incorrecta al utilizar contraseña "válida" (As.12345678)](https://trello.com/c/04gHYYxo/4-devuelve-contrase%C3%B1a-incorrecta-al-utilizar-contrase%C3%B1a-v%C3%A1lida-as12345678)
- [rubular](https://rubular.com/)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Regex matching with the intended password
<img width="1012" alt="image" src="https://github.com/wyeworks/finder/assets/62676004/1559efff-912d-4ca6-bf7d-1572bae0cfae">

#### Signup JSON response including a hash with the errors:
![image](https://github.com/wyeworks/finder/assets/62676004/727e1267-22df-42fd-b8da-31badbdb8c29)