### PR TITLE
[BE] Add Social Networks to Users

### DIFF
--- a/api/app/serializers/user_serializer.rb
+++ b/api/app/serializers/user_serializer.rb
@@ -1,5 +1,8 @@
 class UserSerializer
   include JSONAPI::Serializer
 
-  attributes :id, :email, :name
+  attributes :id,
+             :email,
+             :name,
+             :social_networks
 end

--- a/api/db/migrate/20230910200900_add_social_networks_to_users.rb
+++ b/api/db/migrate/20230910200900_add_social_networks_to_users.rb
@@ -1,0 +1,5 @@
+class AddSocialNetworksToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :social_networks, :json
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_01_205243) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_10_200900) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_01_205243) do
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.json "social_networks"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## What && Why
Add `social_networks` column to `users` table.
It has a JSON type, so that the user's social networks can be presented like this:

```ruby
social_networks: {
  facebook: string,
  instagram: string,
  linkedin: string,
  discord: string,
  x: string
}
```

## How
- [x] Add `social_networks` column to `users` table.
- [x] Add it to the `UserSerializer`.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Agregar redes sociales a Users](https://trello.com/c/7o4RTVAK/84-be-agregar-redes-sociales-a-users)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.