### PR TITLE
Backfill `confirmed_at` column for Users

### DIFF
--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
          :rememberable, :validatable, :confirmable, :jwt_authenticatable,
          jwt_revocation_strategy: Devise::JWT::RevocationStrategies::Null
 
+  PASSWORD_REGEX = /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-.])/
+
   # Validations
   validates :name, :birth_date, presence: true
   validate :password_complexity
@@ -10,7 +12,7 @@ class User < ApplicationRecord
   private
 
   def password_complexity
-    return if password =~ /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-.])/
+    return if password.blank? || password =~ PASSWORD_REGEX
 
     errors.add :password, 'Complexity requirement not met. ' \
                           'Please use: 1 uppercase, 1 lowercase, 1 digit and 1 special character'

--- a/api/db/migrate/20230901205243_add_confirmable_to_devise.rb
+++ b/api/db/migrate/20230901205243_add_confirmable_to_devise.rb
@@ -6,8 +6,6 @@ class AddConfirmableToDevise < ActiveRecord::Migration[7.0]
       t.datetime :confirmation_sent_at
     end
     add_index :users, :confirmation_token, unique: true
-
-    User.update confirmed_at: DateTime.now
   end
 
   def down

--- a/api/db/migrate/20230911000101_backfill_confirmed_at_column_for_users.rb
+++ b/api/db/migrate/20230911000101_backfill_confirmed_at_column_for_users.rb
@@ -1,0 +1,5 @@
+class BackfillConfirmedAtColumnForUsers < ActiveRecord::Migration[7.0]
+  def change
+    User.update confirmed_at: DateTime.now
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_10_200900) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_11_000101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
## What && Why
Backfill `confirmed_at` column for Users.
This operation failed after introducing the email confirmation feature, due to an issue with password complexity validation:
- After a user gets created, `user.password` getter returns `nil` as a way to prevent someone from getting the real password from the DB. It actually gets stored encrypted, and accesible via `user.encrypted_password`. By not having `user.password` available, this was causing issues when trying to update existing users, due to them being invalid.

## How
- [x] Update password complexity validation to prevent having invalid users.
- [x] Backfill `confirmed_at` column for existing users.

## Links
- No ticket for this one.

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.