### PR TITLE
Add `default_url_options` config for Production

### DIFF
--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -50,6 +50,8 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
+  config.action_mailer.default_url_options = { host: 'https://finder-backend-qa.onrender.com' }
+
   config.action_mailer.delivery_method = :smtp
 
   config.action_mailer.smtp_settings = {


### PR DESCRIPTION
## What && Why
Add `default_url_options` config for Production: using QA URL for now.

## How
- [x] Add `default_url_options` config for Productio

## Links
- No ticket

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.