### PR TITLE
Fix `default_url_options` host for production

### DIFF
--- a/api/config/environments/production.rb
+++ b/api/config/environments/production.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
 
   config.action_mailer.perform_caching = false
 
-  config.action_mailer.default_url_options = { host: 'https://finder-backend-qa.onrender.com' }
+  config.action_mailer.default_url_options = { host: 'finder-backend-qa.onrender.com' }
 
   config.action_mailer.delivery_method = :smtp
 


### PR DESCRIPTION
## What && Why
Fix `default_url_options` host for production
