### PR TITLE
Add visibility icon for password

### DIFF
--- a/client/src/app/signin/Form.tsx
+++ b/client/src/app/signin/Form.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import EmailIcon from '@/assets/Icons/EmailIcon';
 import UserIcon from '@/assets/Icons/UserIcon';
 import Alert from '@/components/common/Alert';
 import Button from '@/components/common/Button';
@@ -99,7 +98,6 @@ export default function Form() {
           value={formData.password}
           onChange={handleChange}
           touched={touched.password}
-          Icon={<EmailIcon className='h-5 w-5 text-gray-400' />}
         />
         <Button
           type='submit'

--- a/client/src/app/signin/View.tsx
+++ b/client/src/app/signin/View.tsx
@@ -12,7 +12,7 @@ export default function View() {
           finder.com
         </h2>
         <h2 className='mt-4 text-center text-2xl font-normal leading-9 tracking-tight text-gray-900 sm:mt-10'>
-          Iniciar Sesion
+          Iniciar Sesión
         </h2>
         <p className='mt-1 text-center text-sm tracking-tight text-gray-400'>
           Ingresa a tu cuenta para contactarte con tus compañeros

--- a/client/src/app/signup/Form.tsx
+++ b/client/src/app/signup/Form.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import EmailIcon from '@/assets/Icons/EmailIcon';
-import LockIcon from '@/assets/Icons/LockIcon';
 import UserIcon from '@/assets/Icons/UserIcon';
 import Alert from '@/components/common/Alert';
 import Button from '@/components/common/Button';
@@ -123,7 +122,6 @@ export default function Form() {
           value={formData.password}
           onChange={handleChange}
           touched={touched.password}
-          Icon={<LockIcon className='h-5 w-5 text-gray-400' />}
         />
         <Button
           type='submit'

--- a/client/src/assets/Icons/EyeClosedIcon.tsx
+++ b/client/src/assets/Icons/EyeClosedIcon.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  className: string;
+}
+
+export default function EyeClosedIcon({ className }: Props) {
+  return (
+    <svg
+      className={className}
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <circle cx='12' cy='12' r='3' />
+      <path d='M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21' />
+    </svg>
+  );
+}

--- a/client/src/assets/Icons/EyeIcon.tsx
+++ b/client/src/assets/Icons/EyeIcon.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  className: string;
+}
+
+export default function EyeIcon({ className }: Props) {
+  return (
+    <svg
+      className={className}
+      viewBox='0 0 24 24'
+      fill='none'
+      stroke='currentColor'
+      strokeWidth='2'
+      strokeLinecap='round'
+      strokeLinejoin='round'
+    >
+      <circle cx='12' cy='12' r='3' />
+      <path d='M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z' />
+    </svg>
+  );
+}

--- a/client/src/components/common/Input.tsx
+++ b/client/src/components/common/Input.tsx
@@ -1,3 +1,7 @@
+import EyeClosedIcon from '@/assets/Icons/EyeClosedIcon';
+import EyeIcon from '@/assets/Icons/EyeIcon';
+import { useState } from 'react';
+
 type InputParams = {
   type: string;
   id: string;
@@ -27,6 +31,12 @@ export default function Input({
   onChange,
   Icon,
 }: InputParams) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = () => {
+    setIsVisible(!isVisible);
+  };
+
   return (
     <div className='max-w-sm justify-center'>
       {label && (
@@ -43,17 +53,26 @@ export default function Input({
             {Icon}
           </span>
         )}
+
+        {!Icon && type === 'password' && (
+          <VisibilityToggleButton
+            isVisible={isVisible}
+            toggleVisibility={toggleVisibility}
+          />
+        )}
+
         <input
           id={id}
+          data-testid={id}
           name={name}
-          type={type}
+          type={GetType(type, isVisible)}
           autoComplete={type}
           placeholder={placeholder}
           required={required}
           value={value}
           onChange={onChange}
           className={`peer block w-full rounded-md border-0 px-3 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6 ${
-            Icon && 'pl-10'
+            (Icon || type === 'password') && 'pl-10'
           }`}
         />
         {touched && (
@@ -64,4 +83,33 @@ export default function Input({
       </div>
     </div>
   );
+}
+
+type VisibilityToggleButtonProps = {
+  isVisible: boolean;
+  toggleVisibility: () => void;
+};
+
+function VisibilityToggleButton({
+  isVisible,
+  toggleVisibility,
+}: VisibilityToggleButtonProps) {
+  return (
+    <button
+      type='button'
+      data-testid='visibility-toggle-button'
+      className='absolute inset-y-0 left-0 mt-2 flex h-fit items-center pl-3'
+      onClick={toggleVisibility}
+    >
+      {isVisible ? (
+        <EyeClosedIcon className='h-5 w-5 text-gray-400' />
+      ) : (
+        <EyeIcon className='h-5 w-5 text-gray-400' />
+      )}
+    </button>
+  );
+}
+
+function GetType(type: string, isVisible: boolean) {
+  return type === 'password' ? (isVisible ? 'text' : 'password') : type;
 }

--- a/client/src/components/common/__test__/Input.test.tsx
+++ b/client/src/components/common/__test__/Input.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Input from '../Input';
 
@@ -70,5 +70,28 @@ describe('Input Component', () => {
     // Verify that the icon is rendered
     const iconElement = screen.getByTestId('mock-icon');
     expect(iconElement).toBeInTheDocument();
+  });
+
+  it('should toggle password visibility when the eye icon is clicked', async () => {
+    render(<Input type='password' id='test-password' name='password' />);
+
+    const passwordInput = screen.getByTestId('test-password');
+    const toggleVisibilityButton = screen.getByTestId(
+      'visibility-toggle-button'
+    );
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    userEvent.click(toggleVisibilityButton);
+
+    await waitFor(() => {
+      expect(passwordInput).toHaveAttribute('type', 'text');
+    });
+
+    userEvent.click(toggleVisibilityButton);
+
+    await waitFor(() => {
+      expect(passwordInput).toHaveAttribute('type', 'password');
+    });
   });
 });


### PR DESCRIPTION
## What && Why

Add a button that allows displaying the password being typed.

## How

Make the icon clickable when the field is `password` type and no icon is passed as a prop.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[FE] Registro Usuario - Ver Contraseña](https://trello.com/c/lBDFi8EI/120-fe-registro-usuario-ver-contrase%C3%B1a)

## How to Review
- [ ] Review commit by commit recommended.
- [x] Review all at once recommended.

## Screenshots
![image](https://github.com/wyeworks/finder/assets/105255409/1894fbdc-729a-4b47-aafe-260b8e7a9c29)

![image](https://github.com/wyeworks/finder/assets/105255409/4b604761-7eae-45e1-b6fb-b042118bd0f0)

![image](https://github.com/wyeworks/finder/assets/105255409/17f3bbb3-95ea-4772-bb4a-bd1d7bef452d)

![image](https://github.com/wyeworks/finder/assets/105255409/20e55b74-9725-4ad9-a529-1e4a6aa3be58)


