### PR TITLE
Create `subjects/:id` endpoint for getting Subjects data

### DIFF
--- a/api/app/controllers/subjects_controller.rb
+++ b/api/app/controllers/subjects_controller.rb
@@ -1,0 +1,13 @@
+class SubjectsController < ApplicationController
+  before_action :set_subject
+
+  def show
+    render json: SubjectSerializer.new(@subject).serializable_hash[:data][:attributes]
+  end
+
+  private
+
+  def set_subject
+    @subject = Subject.find(params[:id])
+  end
+end

--- a/api/app/serializers/subject_serializer.rb
+++ b/api/app/serializers/subject_serializer.rb
@@ -1,0 +1,8 @@
+class SubjectSerializer
+  include JSONAPI::Serializer
+
+  attributes :id,
+             :name,
+             :code,
+             :credits
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -12,5 +12,6 @@ Rails.application.routes.draw do
     confirmations: 'users/confirmations'
   }
 
+  resources :subjects, only: :show
   resources :users, only: :show
 end

--- a/api/spec/requests/subjects_controller_spec.rb
+++ b/api/spec/requests/subjects_controller_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe SubjectsController, type: :request do
+  describe 'GET /subjects/:id' do
+    let(:subject) { create :subject }
+
+    before do
+      get subject_path(subject)
+    end
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'returns JSON containing subject data' do
+      json_response = response.parsed_body
+
+      expect(json_response['id']).to eq(subject.id)
+      expect(json_response['name']).to eq(subject.name)
+      expect(json_response['code']).to eq(subject.code)
+      expect(json_response['credits']).to eq(subject.credits)
+    end
+  end
+end


### PR DESCRIPTION
## What && Why
Add new `SubjectsController`, with a `show` action, that will return a JSON with the `SubjectSerializer` for a specific subject, based on their ID.

## How
- [x] Create new `SubjectsController`, with `show` action.
- [x] Update `SubjectSerializer` with newest data.
- [x] Add requests spec for the new controller.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Materias - Read](https://trello.com/c/71ZtXN7w/126-be-materias-read)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Postman
<img width="1661" alt="Screenshot 2023-09-17 at 4 26 09 PM" src="https://github.com/wyeworks/finder/assets/62676004/d83d2a9a-d01c-48ff-a150-829db04241a6">