### PR TITLE
Devise: email subjects translated

### DIFF
--- a/api/config/locales/devise.en.yml
+++ b/api/config/locales/devise.en.yml
@@ -18,15 +18,15 @@ en:
       unconfirmed: "You have to confirm your email address before continuing."
     mailer:
       confirmation_instructions:
-        subject: "Confirmation instructions"
+        subject: "Finder - Instrucciones de confirmación"
       reset_password_instructions:
-        subject: "Reset password instructions"
+        subject: "Finder - Instrucciones de cambio de contraseña"
       unlock_instructions:
-        subject: "Unlock instructions"
+        subject: "Finder - Instrucciones de desbloqueo"
       email_changed:
-        subject: "Email Changed"
+        subject: "Finder - Email modificado"
       password_change:
-        subject: "Password Changed"
+        subject: "Finder - Contraseña modificada"
     omniauth_callbacks:
       failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
       success: "Successfully authenticated from %{kind} account."


### PR DESCRIPTION
## What && Why
Devise mailer subjects: spanish translations

## How
- [x] Subject translated

## Disclaimers / Extra Comments
I tried to load a new .es.yml file but this affects the rest of the app. I leave a link to the [PR](https://github.com/wyeworks/finder/pull/57/files) in case you want to review it


## How to Review
- [x] Register a new user

## Screenshots
![image](https://github.com/wyeworks/finder/assets/77336573/266d9a3d-17bb-4f08-8d5f-605e0fe63cab)