### PR TITLE
Add Subjects `index`

### DIFF
--- a/api/app/controllers/subjects_controller.rb
+++ b/api/app/controllers/subjects_controller.rb
@@ -1,5 +1,13 @@
 class SubjectsController < ApplicationController
-  before_action :set_subject
+  before_action :set_subject, only: :show
+
+  def index
+    subjects = Subject.all.map do |subject|
+      SubjectSerializer.new(subject).serializable_hash[:data][:attributes]
+    end
+
+    render json: subjects
+  end
 
   def show
     render json: SubjectSerializer.new(@subject).serializable_hash[:data][:attributes]

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -12,6 +12,6 @@ Rails.application.routes.draw do
     confirmations: 'users/confirmations'
   }
 
-  resources :subjects, only: :show
+  resources :subjects, only: [:index, :show]
   resources :users, only: :show
 end

--- a/api/spec/requests/subjects_controller_spec.rb
+++ b/api/spec/requests/subjects_controller_spec.rb
@@ -1,6 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe SubjectsController, type: :request do
+  describe 'GET /subjects' do
+    let(:subjects) { create_list :subject, 2 }
+
+    before do
+      get subjects_path(subjects)
+    end
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'returns JSON containing all subjects data' do
+      json_response = response.parsed_body
+
+      expect(json_response[0]['id']).to be_a(Integer)
+      expect(json_response[0]['name']).to be_a(String)
+      expect(json_response[0]['code']).to be_a(String)
+      expect(json_response[0]['credits']).to be_a(Integer)
+    end
+  end
+
   describe 'GET /subjects/:id' do
     let(:subject) { create :subject }
 


### PR DESCRIPTION
## What && Why
Add `/subjects` endpoint for getting all subjects.
This is required for the FE to be able to display a dropdown with all the subject options, when creating a new `group`.

## How
- [x] Add new `index` action to `SubjectsController`.
- [x] Add request spec.

## Disclaimers / Extra Comments
There was a discussion with @andresconti if this was necessary, in #54. We decided back then that it was not required at the moment.
However, @santimintegui asked for it as he is working on the FE feature for displaying all subjects when creating a `group`.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Endpoint para obtener las materias](https://trello.com/c/uSs0vzZ9/133-be-endpoint-para-obtener-las-materias)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Postman
<img width="1659" alt="Screenshot 2023-09-19 at 7 59 35 AM" src="https://github.com/wyeworks/finder/assets/62676004/fbaee5d4-7c84-4222-b260-d45feeea5223">