### PR TITLE
Load Careers from Seed file

### DIFF
--- a/api/app/models/career.rb
+++ b/api/app/models/career.rb
@@ -1,6 +1,5 @@
 class Career < ApplicationRecord
   # Associations
-  has_and_belongs_to_many :subjects
   has_and_belongs_to_many :users
 
   # Validations

--- a/api/app/models/subject.rb
+++ b/api/app/models/subject.rb
@@ -1,7 +1,6 @@
 class Subject < ApplicationRecord
   # Associations
   has_many :groups, dependent: :nullify
-  has_and_belongs_to_many :careers
 
   # Validations
   validates :name, :credits, :code, presence: true

--- a/api/db/migrate/20230921233002_drop_careers_subjects.rb
+++ b/api/db/migrate/20230921233002_drop_careers_subjects.rb
@@ -1,0 +1,11 @@
+class DropCareersSubjects < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :careers_subjects, if_exists: true do |t|
+      t.index :career_id
+      t.index :subject_id
+      t.index %i[career_id subject_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_19_234830) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_21_233002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,16 +23,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_19_234830) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_careers_on_code", unique: true
-  end
-
-  create_table "careers_subjects", id: false, force: :cascade do |t|
-    t.bigint "career_id", null: false
-    t.bigint "subject_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["career_id", "subject_id"], name: "index_careers_subjects_on_career_id_and_subject_id", unique: true
-    t.index ["career_id"], name: "index_careers_subjects_on_career_id"
-    t.index ["subject_id"], name: "index_careers_subjects_on_subject_id"
   end
 
   create_table "careers_users", id: false, force: :cascade do |t|

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -199,3 +199,28 @@ Subject.create(name: 'Imágenes Medicas:adq. Instrum. Y Gestión', code: '5709',
 Subject.create(name: 'Planificacion De Clases: Diseño De Unid.didact.', code: '1213', credits: 2)
 Subject.create(name: 'Taller Encarare 1:creatividad E Innovac.', code: '2034', credits: 5)
 Subject.create(name: 'Taller Encarare 2:planif.de La Fut.empr.', code: '2036', credits: 5)
+
+# Careers
+
+Career.create(name: 'Agrimensura', code: '42-0', approved_on: '1997', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Civil', code: '22-5', approved_on: '2021', years: 5, credits: 450)
+Career.create(name: 'Ingeniería de Alimentos', code: '56-0', approved_on: '2003', years: 5, credits: 450)
+Career.create(name: 'Ingeniería de Producción', code: '22-2', approved_on: '2010', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Eléctrica', code: '22-8', approved_on: '2022', years: 5, credits: 450)
+Career.create(name: 'Ingeniería en Computación', code: '72', approved_on: '1997', years: 5, credits: 450)
+Career.create(name: 'Ingeniería en Sistemas de Comunicación', code: 'ISC', approved_on: '2018', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Físico-Matemática', code: 'IFM', approved_on: '2017', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Forestal (Tacuarembó)', code: 'IFT', approved_on: '2013', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Industrial Mecánica', code: '22-3', approved_on: '1997', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Naval', code: '22-4', approved_on: '1997', years: 5, credits: 450)
+Career.create(name: 'Ingeniería Química', code: '53-0', approved_on: '2022', years: 5, credits: 450)
+Career.create(name: 'Lic. en Ciencias de la Atmósfera', code: '45-0', approved_on: '2006', years: 4, credits: 360)
+Career.create(name: 'Lic. en Computación', code: '73-0', approved_on: '2012', years: 4, credits: 360)
+Career.create(name: 'Lic. en Ingeniería Biológica', code: 'LIB', approved_on: '2013', years: 4, credits: 360)
+Career.create(
+  name: 'Lic. en Recursos Hídricos y Riego (RN-Salto)',
+  code: 'LRHR',
+  approved_on: '2017',
+  years: 4,
+  credits: 360
+)

--- a/api/spec/factories/subject.rb
+++ b/api/spec/factories/subject.rb
@@ -3,7 +3,5 @@ FactoryBot.define do
     sequence(:name) { |n| "Subject_#{n}" }
     sequence(:code, &:to_s)
     credits { 10 }
-
-    careers { build_list :career, 1, subjects: [] }
   end
 end

--- a/api/spec/models/career_spec.rb
+++ b/api/spec/models/career_spec.rb
@@ -2,7 +2,6 @@ require 'rails_helper'
 
 RSpec.describe Career, type: :model do
   describe 'associations' do
-    it { should have_and_belong_to_many(:subjects) }
     it { should have_and_belong_to_many(:users) }
   end
 

--- a/api/spec/models/subject_spec.rb
+++ b/api/spec/models/subject_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 RSpec.describe Subject, type: :model do
   describe 'associations' do
     it { should have_many(:groups).dependent(:nullify) }
-    it { should have_and_belong_to_many(:careers) }
   end
 
   describe 'validations' do


### PR DESCRIPTION
## What && Why
Load a set of 16 `careers` from the `seed.rb` file into the database.
[Fing careers list](https://www.fing.edu.uy/es/ensenanza/carreras-de-grado-old)

## How
- [x] Remove table and association between `subjects` and `careers`, based on discussion with @nodescanses [here](https://github.com/wyeworks/finder/pull/63#discussion_r1332162920).
- [x] Add list of careers to `seed.rb` file.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Crear seed para carga inicial Carreras](https://trello.com/c/t4jfb3uQ/129-be-crear-seed-para-carga-inicial-carreras)
- [Fing careers list](https://www.fing.edu.uy/es/ensenanza/carreras-de-grado-old)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Output
```
== 20230921233002 DropCareersSubjects: migrating ==============================
-- drop_table(:careers_subjects, {:if_exists=>true})
   -> 0.0025s
== 20230921233002 DropCareersSubjects: migrated (0.0026s) =====================
```