### PR TITLE
Add Careers `index`

### DIFF
--- a/api/app/controllers/careers_controller.rb
+++ b/api/app/controllers/careers_controller.rb
@@ -1,0 +1,9 @@
+class CareersController < ApplicationController
+  def index
+    careers = Career.all.map do |career|
+      CareerSerializer.new(career).serializable_hash[:data][:attributes]
+    end
+
+    render json: careers
+  end
+end

--- a/api/app/serializers/career_serializer.rb
+++ b/api/app/serializers/career_serializer.rb
@@ -1,0 +1,10 @@
+class CareerSerializer
+  include JSONAPI::Serializer
+
+  attributes :id,
+             :name,
+             :code,
+             :approved_on,
+             :years,
+             :credits
+end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     confirmations: 'users/confirmations'
   }
 
+  resources :careers, only: :index
   resources :subjects, only: [:index, :show]
   resources :users, only: :show
 end

--- a/api/spec/factories/career.rb
+++ b/api/spec/factories/career.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :career do
     sequence(:name) { |n| "Career_#{n}" }
     sequence(:code, &:to_s)
+    approved_on { '2023' }
     years { 5 }
     credits { 450 }
   end

--- a/api/spec/requests/careers_controller_spec.rb
+++ b/api/spec/requests/careers_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.describe CareersController, type: :request do
+  describe 'GET /careers' do
+    let(:careers) { create_list :career, 2 }
+
+    before do
+      get careers_path(careers)
+    end
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it 'returns JSON containing all careers data' do
+      json_response = response.parsed_body
+
+      expect(json_response[0]['id']).to be_a(Integer)
+      expect(json_response[0]['name']).to be_a(String)
+      expect(json_response[0]['code']).to be_a(String)
+      expect(json_response[0]['approved_on']).to be_a(String)
+      expect(json_response[0]['years']).to be_a(Integer)
+      expect(json_response[0]['credits']).to be_a(Integer)
+    end
+  end
+end


### PR DESCRIPTION
## What && Why
Add `GET /careers` endpoint for getting all careers.
This is required for the FE to be able to display a dropdown with all the career options, when editing a user's profile.

## How
- [x] Add new `CareersController` and `index` action.
- [x] Add `CareerSerializer`.
- [x] Add request spec.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Endpoint para obtener las carreras](https://trello.com/c/USZM8caS/136-be-endpoint-para-obtener-las-carreras)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Postman
<img width="1653" alt="Screenshot 2023-09-22 at 9 41 02 AM" src="https://github.com/wyeworks/finder/assets/62676004/9ac267b3-8e9d-4a3e-9ffc-a463be7523d1">