### PR TITLE
Create `users/:id/careers` and `users/:id/subjects` Endpoints

### DIFF
--- a/api/app/controllers/users_controller.rb
+++ b/api/app/controllers/users_controller.rb
@@ -13,6 +13,14 @@ class UsersController < ApplicationController
     render json: careers
   end
 
+  def subjects
+    subjects = @user.subjects.map do |subject|
+      SubjectSerializer.new(subject).serializable_hash[:data][:attributes]
+    end
+
+    render json: subjects
+  end
+
   private
 
   def set_user

--- a/api/app/controllers/users_controller.rb
+++ b/api/app/controllers/users_controller.rb
@@ -5,6 +5,14 @@ class UsersController < ApplicationController
     render json: UserSerializer.new(@user).serializable_hash[:data][:attributes]
   end
 
+  def careers
+    careers = @user.careers.map do |career|
+      CareerSerializer.new(career).serializable_hash[:data][:attributes]
+    end
+
+    render json: careers
+  end
+
   private
 
   def set_user

--- a/api/app/models/subject.rb
+++ b/api/app/models/subject.rb
@@ -1,6 +1,7 @@
 class Subject < ApplicationRecord
   # Associations
   has_many :groups, dependent: :nullify
+  has_and_belongs_to_many :users
 
   # Validations
   validates :name, :credits, :code, presence: true

--- a/api/app/models/user.rb
+++ b/api/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :members, dependent: :destroy
   has_many :groups, through: :members
   has_and_belongs_to_many :careers
+  has_and_belongs_to_many :subjects
 
   # Validations
   validates :name, presence: true

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -13,9 +13,9 @@ Rails.application.routes.draw do
   }
 
   resources :careers, only: :index
-  resources :subjects, only: [:index, :show]
-
   resources :groups, except: [:new, :edit]
-
-  resources :users, only: :show
+  resources :subjects, only: [:index, :show]
+  resources :users, only: :show do
+    get :careers, on: :member
+  end
 end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
   resources :groups, except: [:new, :edit]
   resources :subjects, only: [:index, :show]
   resources :users, only: :show do
-    get :careers, on: :member
+    member do
+      get :careers
+      get :subjects
+    end
   end
 end

--- a/api/db/migrate/20230923204150_create_join_table_subject_user.rb
+++ b/api/db/migrate/20230923204150_create_join_table_subject_user.rb
@@ -1,0 +1,11 @@
+class CreateJoinTableSubjectUser < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :subjects, :users, if_not_exists: true do |t|
+      t.index :subject_id
+      t.index :user_id
+      t.index %i[subject_id user_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_23_001429) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_23_204150) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -64,6 +64,16 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_23_001429) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code"], name: "index_subjects_on_code", unique: true
+  end
+
+  create_table "subjects_users", id: false, force: :cascade do |t|
+    t.bigint "subject_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["subject_id", "user_id"], name: "index_subjects_users_on_subject_id_and_user_id", unique: true
+    t.index ["subject_id"], name: "index_subjects_users_on_subject_id"
+    t.index ["user_id"], name: "index_subjects_users_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/api/spec/factories/user.rb
+++ b/api/spec/factories/user.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
 
     careers { build_list :career, 1, users: [] }
 
+    subjects { build_list :subject, 1, users: [] }
+
     trait :with_confirmation_token do
       confirmed_at { nil }
       confirmation_token { 'some_token' }

--- a/api/spec/models/subject_spec.rb
+++ b/api/spec/models/subject_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Subject, type: :model do
   describe 'associations' do
     it { should have_many(:groups).dependent(:nullify) }
+    it { should have_and_belong_to_many(:users) }
   end
 
   describe 'validations' do

--- a/api/spec/models/user_spec.rb
+++ b/api/spec/models/user_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe User, type: :model do
     it { should have_many(:members).dependent(:destroy) }
     it { should have_many(:groups).through(:members) }
     it { should have_and_belong_to_many(:careers) }
+    it { should have_and_belong_to_many(:subjects) }
   end
 
   describe 'validations' do

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -47,4 +47,27 @@ RSpec.describe UsersController, type: :request do
       expect(json_response[0]['credits']).to be_a(Integer)
     end
   end
+
+  describe 'GET /users/:id/subjects' do
+    let(:user) { create :user }
+
+    before do
+      create_list(:subject, 2, users: [user])
+
+      get subjects_user_path(user)
+    end
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it "returns JSON containing user's subjects data" do
+      json_response = response.parsed_body
+
+      expect(json_response[0]['id']).to be_a(Integer)
+      expect(json_response[0]['name']).to be_a(String)
+      expect(json_response[0]['code']).to be_a(String)
+      expect(json_response[0]['credits']).to be_a(Integer)
+    end
+  end
 end

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -22,4 +22,29 @@ RSpec.describe UsersController, type: :request do
       expect(json_response['social_networks']).to eq(user.social_networks)
     end
   end
+
+  describe 'GET /users/:id/careers' do
+    let(:user) { create :user }
+
+    before do
+      create_list(:career, 2, users: [user])
+
+      get careers_user_path(user)
+    end
+
+    it 'returns a successful response' do
+      expect(response).to be_successful
+    end
+
+    it "returns JSON containing user's careers data" do
+      json_response = response.parsed_body
+
+      expect(json_response[0]['id']).to be_a(Integer)
+      expect(json_response[0]['name']).to be_a(String)
+      expect(json_response[0]['code']).to be_a(String)
+      expect(json_response[0]['approved_on']).to be_a(String)
+      expect(json_response[0]['years']).to be_a(Integer)
+      expect(json_response[0]['credits']).to be_a(Integer)
+    end
+  end
 end


### PR DESCRIPTION
## What && Why
Add relationship between `subjects` and `users`.
Create `users/:id/careers` and `users/:id/subjects` endpoints, that will be useful (and needed) for the User's profile page in the FE.

## How
- [x] Create join table between `subjects` and `users`.
- [x] Add associations to the models.
- [x] Update specs and factories.
- [x] Add `users/:id/careers` route and endpoint. 
- [x] Add `users/:id/subjects` route and endpoint.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Rutas Careers y Subjects](https://trello.com/c/yIvqXfC1/143-be-rutas-careers-y-subjects)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Output
```
== 20230923204150 CreateJoinTableSubjectUser: migrating =======================
-- create_join_table(:subjects, :users, {:if_not_exists=>true})
   -> 0.0142s
== 20230923204150 CreateJoinTableSubjectUser: migrated (0.0143s) ==============
```

## Screenshots
#### Postman: get user's careers
<img width="1651" alt="Screenshot 2023-09-23 at 6 17 09 PM" src="https://github.com/wyeworks/finder/assets/62676004/ae7add23-9c4d-4f39-bfad-c70252b40888">

#### Postman: get user's subjects
<img width="1654" alt="Screenshot 2023-09-23 at 6 27 46 PM" src="https://github.com/wyeworks/finder/assets/62676004/4407e4d0-773e-4323-b35c-217c22ff604c">