### PR TITLE
Allow Careers and Subjects to be updated for Users

### DIFF
--- a/api/app/controllers/users/registrations_controller.rb
+++ b/api/app/controllers/users/registrations_controller.rb
@@ -104,7 +104,9 @@ module Users
               :name,
               :birth_date,
               :bio,
-              social_networks: {}
+              social_networks: {},
+              career_ids: [],
+              subject_ids: []
             )
     end
   end

--- a/api/app/serializers/career_serializer.rb
+++ b/api/app/serializers/career_serializer.rb
@@ -6,5 +6,6 @@ class CareerSerializer
              :code,
              :approved_on,
              :years,
-             :credits
+             :credits,
+             :user_ids
 end

--- a/api/app/serializers/group_serializer.rb
+++ b/api/app/serializers/group_serializer.rb
@@ -6,7 +6,8 @@ class GroupSerializer
              :description,
              :size,
              :time_preferences,
-             :subject_id
+             :subject_id,
+             :user_ids
 
   belongs_to :subject
 end

--- a/api/app/serializers/subject_serializer.rb
+++ b/api/app/serializers/subject_serializer.rb
@@ -4,5 +4,7 @@ class SubjectSerializer
   attributes :id,
              :name,
              :code,
-             :credits
+             :credits,
+             :group_ids,
+             :user_ids
 end

--- a/api/app/serializers/user_serializer.rb
+++ b/api/app/serializers/user_serializer.rb
@@ -9,5 +9,8 @@ class UserSerializer
              :email,
              :name,
              :bio,
-             :social_networks
+             :social_networks,
+             :group_ids,
+             :career_ids,
+             :subject_ids
 end

--- a/api/spec/requests/users/registrations_controller_spec.rb
+++ b/api/spec/requests/users/registrations_controller_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Users::RegistrationsController, type: :request do
         instagram: 'new_instagram_link'
       }
     end
+    let(:new_career) { create :career }
+    let(:new_subject) { create :subject }
 
     before do
       post user_session_path, params: { user: { email: user.email, password: user.password } }
@@ -71,7 +73,9 @@ RSpec.describe Users::RegistrationsController, type: :request do
                 password: new_password,
                 birth_date: new_birth_date,
                 bio: new_bio,
-                social_networks: new_social_networks
+                social_networks: new_social_networks,
+                career_ids: [new_career.id],
+                subject_ids: [new_subject.id]
               }
             }.to_json,
             headers: {
@@ -92,12 +96,16 @@ RSpec.describe Users::RegistrationsController, type: :request do
         expect(json_response['user']['birth_date']).to eq(new_birth_date.to_s)
         expect(json_response['user']['bio']).to eq(new_bio)
         expect(json_response['user']['social_networks']).to eq(new_social_networks.with_indifferent_access)
+        expect(json_response['user']['career_ids']).to include(new_career.id)
+        expect(json_response['user']['subject_ids']).to include(new_subject.id)
 
         user.reload
 
         expect(user.birth_date).to eq(new_birth_date.to_s)
         expect(user.bio).to eq(new_bio)
         expect(user.social_networks).to eq(new_social_networks.with_indifferent_access)
+        expect(user.careers).to include(new_career)
+        expect(user.subjects).to include(new_subject)
       end
 
       it 'updates user password' do


### PR DESCRIPTION
## What && Why
Allow `Careers` and `Subjects` to be updated for `Users`.

## How
- [x] Update `RegistrationsController`, adding `career_ids` and `subject_ids`.
- [x] Improve serializers to start returning associations data.
- [x] Update spec.
- [x] Test with Postman.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) No ticket.

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Postman PATCH
<img width="1657" alt="Screenshot 2023-09-24 at 9 11 13 PM" src="https://github.com/wyeworks/finder/assets/62676004/9aa26a11-1e9f-4ecb-aeb1-ef5d730167a1">