### PR TITLE
fix autocomplete in Signup

### DIFF
--- a/client/src/app/signup/Form.tsx
+++ b/client/src/app/signup/Form.tsx
@@ -100,6 +100,7 @@ export default function Form() {
         className='grid max-w-xs grid-rows-register-form gap-1 sm:pl-7'
         onSubmit={handleSubmit}
         noValidate
+        autoComplete='off'
       >
         <Input
           type='text'
@@ -140,6 +141,7 @@ export default function Form() {
           value={formData.password}
           onChange={handleChange}
           touched={touched.password}
+          autoComplete='new-password'
         />
         <Button
           type='submit'

--- a/client/src/components/common/Input.tsx
+++ b/client/src/components/common/Input.tsx
@@ -25,6 +25,7 @@ type InputParams = {
   classNameInput?: string;
   minNumber?: number;
   max?: string | number;
+  autoComplete?: string;
 };
 
 export default function Input({
@@ -46,6 +47,7 @@ export default function Input({
   classNameInput = '',
   minNumber,
   max,
+  autoComplete = type,
 }: InputParams) {
   const [isVisible, setIsVisible] = useState(false);
 
@@ -99,7 +101,7 @@ export default function Input({
           data-testid={id}
           name={name}
           type={GetType(type, isVisible)}
-          autoComplete={type}
+          autoComplete={autoComplete}
           placeholder={placeholder}
           required={required}
           value={value}


### PR DESCRIPTION
## What && Why
Evitar que los campos del registro se autocompleten con los campos de login, para esto le deshabilite el autocomplete en el signup.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [Evitar que los campos del registro se autocompleten con los campos de login](https://trello.com/c/WKy76LVM)

## How to Review
- [ ] Review commit by commit recommended.
- [x] Review all at once recommended.

Antes:
![image](https://github.com/wyeworks/finder/assets/79933970/b9e9b5a2-c60b-43cd-a76a-dc7973f1a25a)

Ahora:
![Screenshot 2023-09-27 at 14 27 24](https://github.com/wyeworks/finder/assets/79933970/08f58c22-adfd-480b-b021-fb788669e099)
