### PR TITLE
fix(manejoDeError): En signup

### DIFF
--- a/client/src/services/ApiCommunicator.ts
+++ b/client/src/services/ApiCommunicator.ts
@@ -165,6 +165,7 @@ export class ApiCommunicator {
       method: 'POST',
       data,
       asJSON: false,
+      handleNotOk: false,
     });
   }
 


### PR DESCRIPTION
## What && Why
No estaba mostrando los mensajes de error especificos devueltos por backend. Lo unico que faltaba era decirle al metodo que no se encargara el de manejar la response notOK porque se maneja en front de manera personalizada

## Links
- [issue](https://trello.com/c/zVKIXid8/199-manejo-de-errores-arreglo)
