### PR TITLE
Add subject_name in /groups and /groups/:id response

### DIFF
--- a/api/app/serializers/group_serializer.rb
+++ b/api/app/serializers/group_serializer.rb
@@ -7,7 +7,12 @@ class GroupSerializer
              :size,
              :time_preferences,
              :subject_id,
+             :subject_name,
              :user_ids
 
   belongs_to :subject
+
+  attribute :subject_name do |group|
+    group.subject.name
+  end
 end

--- a/api/spec/requests/groups_controller_spec.rb
+++ b/api/spec/requests/groups_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe GroupsController, type: :request do
       expect(json_response[0]['size']).to be_a(Integer)
       expect(json_response[0]['time_preferences']).to be_a(Hash)
       expect(json_response[0]['subject_id']).to be_a(Integer)
+      expect(json_response[0]['subject_name']).to be_a(String)
     end
   end
 
@@ -49,6 +50,7 @@ RSpec.describe GroupsController, type: :request do
         expect(json_response['size']).to eq(group.size)
         expect(json_response['time_preferences']).to eq(group.time_preferences)
         expect(json_response['subject_id']).to eq(group.subject_id)
+        expect(json_response['subject_name']).to eq(group.subject.name)
       end
     end
 


### PR DESCRIPTION
- Agrego subject_name al serializador de la respuesta
- Actualizo los specs para incluir el nuevo campo

![image](https://github.com/wyeworks/finder/assets/77336573/5547d0fc-49a9-4fef-918f-f2e93a7e3763)
![image](https://github.com/wyeworks/finder/assets/77336573/48c96b2f-b51c-4c1d-966a-0c5fb26f354e)
