### PR TITLE
add user info in GET requests

### DIFF
--- a/api/app/serializers/request_serializer.rb
+++ b/api/app/serializers/request_serializer.rb
@@ -5,5 +5,14 @@ class RequestSerializer
              :status,
              :reason,
              :group_id,
-             :user_id
+             :user_id,
+             :user_name,
+             :user_email
+
+  attribute :user_name do |group|
+    group.user.name
+  end
+  attribute :user_email do |group|
+    group.user.email
+  end
 end

--- a/api/spec/requests/groups/requests_controller_spec.rb
+++ b/api/spec/requests/groups/requests_controller_spec.rb
@@ -246,7 +246,9 @@ RSpec.describe 'Groups::Requests', type: :request do
             'id' => be_a(Integer),
             'status' => 'pending',
             'group_id' => group.id,
-            'user_id' => be_a(Integer)
+            'user_id' => be_a(Integer),
+            'user_name' => be_a(String),
+            'user_email' => be_a(String)
           )
         end
       end


### PR DESCRIPTION
Agrego user_name y user_email al serializador de la respuesta
Actualizo los specs para incluir el nuevo campo

![image](https://github.com/wyeworks/finder/assets/77336573/685b1bd8-b3ae-476a-a31c-f47a424d886a)
