### PR TITLE
change to 12 groups per page

### DIFF
--- a/client/src/app/(protected)/groups/View.tsx
+++ b/client/src/app/(protected)/groups/View.tsx
@@ -14,7 +14,7 @@ type ViewProps = {
 
 export default function View({ groups, subjects }: ViewProps) {
   const [currentPage, setCurrentPage] = useState(1);
-  const itemsPerPage = 16;
+  const itemsPerPage = 12;
   const [displayGroups, setDisplayGroups] = useState<StudyGroup[]>([]);
 
   useEffect(() => {


### PR DESCRIPTION
## What && Why
- list 12 groups instead of 16 per page
