### PR TITLE
Add Backend Coverage

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -27,5 +27,7 @@
 
 # Ignore master key for decrypting production credentials and more.
 /config/credentials/production.key
-
 /config/credentials/staging.key
+
+# Ignore coverage files
+coverage

--- a/api/Gemfile
+++ b/api/Gemfile
@@ -19,6 +19,7 @@ group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails', '~> 6.2'
   gem 'rspec-rails', '~> 6.0'
+  gem 'simplecov', '~> 0.22'
 end
 
 group :development do

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       devise (~> 4.0)
       warden-jwt_auth (~> 0.8)
     diff-lcs (1.5.0)
+    docile (1.4.0)
     dry-auto_inject (1.0.1)
       dry-core (~> 1.0)
       zeitwerk (~> 2.6)
@@ -236,6 +237,12 @@ GEM
       ruby_http_client (~> 3.4)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     thor (1.2.2)
     timeout (0.4.0)
     tzinfo (2.0.6)
@@ -273,6 +280,7 @@ DEPENDENCIES
   rubocop-rails
   sendgrid-ruby (~> 6.0)
   shoulda-matchers (~> 5.0)
+  simplecov (~> 0.22)
   tzinfo-data
 
 RUBY VERSION

--- a/api/spec/rails_helper.rb
+++ b/api/spec/rails_helper.rb
@@ -1,3 +1,7 @@
+# Calculate test coverage
+require 'simplecov'
+SimpleCov.start 'rails'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
## What && Why
Add backend coverage using `simplecov` gem.
One of the non-functional requirements.

## Usage
1. Run tests with `bundle exec rspec`
2. Last line of the output will be: 
_"Coverage report generated for RSpec to /Users/juan_arias/Development/fing/finder/api/coverage. 356 / 395 LOC (90.13%) covered."_
3. Open html file located in: _"file:///Users/juan_arias/Development/fing/finder/api/coverage/index.html"_

## How
- [x] Add `simplecov` to Gemfile.
- [x] Configure rspec for generating coverage html file when running tests.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) No ticket.
- [simplecov gem](https://github.com/simplecov-ruby/simplecov)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
<img width="1367" alt="Screenshot 2023-10-10 at 6 25 37 PM" src="https://github.com/wyeworks/finder/assets/62676004/a709ca09-aa18-421c-8d52-2ce2525e2ecf">

<img width="1778" alt="Screenshot 2023-10-10 at 6 26 41 PM" src="https://github.com/wyeworks/finder/assets/62676004/e37fba81-2923-4923-82c5-83fc6dbc56d6">