### PR TITLE
Enable Search by params on Groups

### DIFF
--- a/api/.rubocop.yml
+++ b/api/.rubocop.yml
@@ -15,6 +15,9 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Style/Lambda:
+  EnforcedStyle: literal
+
 Metrics/AbcSize:
   Enabled: false
 

--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -5,7 +5,7 @@ class GroupsController < ApplicationController
   before_action :authorize_group_admin!, only: %i[update destroy]
 
   def index
-    groups = Group.all.map do |group|
+    groups = search_result.map do |group|
       GroupSerializer.new(group).serializable_hash[:data][:attributes]
     end
 
@@ -92,5 +92,18 @@ class GroupsController < ApplicationController
 
   def group_params
     params.require(:group).permit(:name, :description, :size, :subject_id, time_preferences: {})
+  end
+
+  def search_params
+    params.permit(:name, :subject_id, :time_preference, :my_groups)
+  end
+
+  def search_result
+    groups = search_params[:my_groups] == 'true' ? current_user.groups : Group
+
+    groups.search_by_params(
+      name: search_params[:name],
+      subject_id: search_params[:subject_id]
+    )
   end
 end

--- a/api/app/controllers/groups_controller.rb
+++ b/api/app/controllers/groups_controller.rb
@@ -95,7 +95,7 @@ class GroupsController < ApplicationController
   end
 
   def search_params
-    params.permit(:name, :subject_id, :time_preference, :my_groups)
+    params.permit(:name, :subject_id, :my_groups, :time_preferences)
   end
 
   def search_result
@@ -104,6 +104,6 @@ class GroupsController < ApplicationController
     groups.search_by_params(
       name: search_params[:name],
       subject_id: search_params[:subject_id]
-    )
+    ).sort_by_time_preferences(time_preferences: search_params[:time_preferences])
   end
 end

--- a/api/app/models/group.rb
+++ b/api/app/models/group.rb
@@ -29,6 +29,14 @@ class Group < ApplicationRecord
   validates :size, numericality: { only_integer: true }
   validate :validate_time_preferences
 
+  # Scopes
+  scope :search_by_params, ->(name:, subject_id:) do
+    groups = where('name ILIKE ?', "%#{name}%")
+    groups = groups.where('cast(subject_id as text) = ?', subject_id.to_s) if subject_id
+
+    groups
+  end
+
   def admin?(user)
     members.exists?(user:, role: 'admin')
   end

--- a/api/spec/models/group_spec.rb
+++ b/api/spec/models/group_spec.rb
@@ -34,6 +34,55 @@ RSpec.describe Group, type: :model do
     end
   end
 
+  describe 'scopes' do
+    describe 'search_by_params' do
+      let(:subject) { described_class.search_by_params(name:, subject_id:) }
+
+      let(:subject_one) { create :subject }
+      let(:subject_two) { create :subject }
+
+      let(:group_one) { create :group, name: 'Foo', subject_id: subject_one.id }
+      let(:group_two) { create :group, name: 'Bar', subject_id: subject_one.id }
+      let(:group_three) { create :group, name: 'Baz', subject_id: subject_two.id }
+
+      context 'when name is passed as a parameter' do
+        let(:name) { 'Ba' }
+        let(:subject_id) { nil }
+
+        it 'returns groups that matches that name' do
+          expect(subject).to match_array([group_two, group_three])
+        end
+      end
+
+      context 'when subject_id is passed as a parameter' do
+        let(:name) { nil }
+        let(:subject_id) { subject_one.id }
+
+        it 'returns groups with that exact subject_id' do
+          expect(subject).to match_array([group_one, group_two])
+        end
+      end
+
+      context 'when both name and subject_id are passed as parameters' do
+        let(:name) { 'Ba' }
+        let(:subject_id) { subject_one.id }
+
+        it 'returns groups that match that criteria' do
+          expect(subject).to match_array([group_two])
+        end
+      end
+
+      context 'when no parameters are passed' do
+        let(:name) { nil }
+        let(:subject_id) { nil }
+
+        it 'returns all groups' do
+          expect(subject).to match_array([group_one, group_two, group_three])
+        end
+      end
+    end
+  end
+
   describe '#admin?' do
     let(:group) { create :group }
     let(:user) { create :user }

--- a/api/spec/models/group_spec.rb
+++ b/api/spec/models/group_spec.rb
@@ -81,6 +81,33 @@ RSpec.describe Group, type: :model do
         end
       end
     end
+
+    describe 'sort_by_time_preferences' do
+      let(:subject) { described_class.sort_by_time_preferences(time_preferences:) }
+
+      let!(:group_one) do
+        create :group, time_preferences: { 'Monday' => 'Night', 'Tuesday' => 'Afternoon', 'Wednesday' => 'Night' }
+      end
+      let!(:group_two) { create :group, time_preferences: { 'Monday' => 'Morning' } }
+      let!(:group_three) { create :group, time_preferences: { 'Monday' => 'Night' } }
+
+      context 'when no time_preferences are passed' do
+        let(:time_preferences) { nil }
+
+        it 'returns all groups in the same previous order' do
+          expect(subject).to match_array([group_one, group_two, group_three])
+        end
+      end
+
+      context 'when time_preferences are passed' do
+        let(:time_preferences) { 'night,afternoon' }
+
+        it 'returns the sorted collection of groups based on the time preferences' do
+          expect(subject.first).to eq(group_one)
+          expect(subject.last).to eq(group_three)
+        end
+      end
+    end
   end
 
   describe '#admin?' do

--- a/api/spec/requests/groups_controller_spec.rb
+++ b/api/spec/requests/groups_controller_spec.rb
@@ -43,6 +43,59 @@ RSpec.describe GroupsController, type: :request do
         expect(response).to have_http_status(:unauthorized)
       end
     end
+
+    context 'when passing search and filter params' do
+      let!(:group_one) do
+        create :group,
+               name: 'Foo',
+               subject: subject_two,
+               time_preferences: { 'Monday' => 'Night', 'Tuesday' => 'Afternoon', 'Wednesday' => 'Night' }
+      end
+      let!(:group_two) do
+        create :group,
+               name: 'Bar',
+               subject: subject_one,
+               time_preferences: { 'Monday' => 'Morning' }
+      end
+      let!(:group_three) do
+        create :group,
+               name: 'Baz',
+               subject: subject_one,
+               time_preferences: { 'Monday' => 'Night' }
+      end
+
+      let(:subject_one) { create :subject }
+      let(:subject_two) { create :subject }
+
+      before do
+        create(:member, user:, group: group_three)
+
+        get groups_path(groups),
+            params: {
+              name: 'ba',
+              subject_id: subject_one.id.to_s,
+              my_groups: 'true',
+              time_preferences: 'night,afternoon'
+            },
+            headers:
+      end
+
+      it 'returns a successful response' do
+        expect(response).to be_successful
+      end
+
+      it 'returns JSON containing data from the groups that match the search params' do
+        json_response = response.parsed_body
+
+        expect(json_response[0]['id']).to be_a(Integer)
+        expect(json_response[0]['name']).to eq(group_three.name)
+        expect(json_response[0]['description']).to eq(group_three.description)
+        expect(json_response[0]['size']).to eq(group_three.size)
+        expect(json_response[0]['time_preferences']).to eq(group_three.time_preferences)
+        expect(json_response[0]['subject_id']).to eq(group_three.subject_id)
+        expect(json_response[0]['subject_name']).to eq(group_three.subject.name)
+      end
+    end
   end
 
   # Show


### PR DESCRIPTION
## What && Why
Enable `search` by params on `Groups`.
This is not a new endpoint. Will use same `index` action and `GET /groups` endpoint, but passing params for searching and filtering.
This is not a disruptive change, so if no params are passed, behavior is still the same.

## Time Preferences
Algorithm for sorting groups by the chosen time preference(s) works like this:
- If no preferences are specified as params, it does nothing.
- If there's a typo or any other invalid value is passed as parameter as `time_preference`, it will be excluded.
- If valid params are passed as `time_preferences`, sums how many times the preferences are present for each group, and sorts them out (first one is the one with more "matches").

## Examples on how to use the endpoint:

```ruby
GET /groups?subject_id=1&name=test&my_groups=true

GET /groups?subject_id=1

GET /groups?subject_id=1&name=test

GET /groups?my_groups=true

GET /groups?name=test

GET /groups?time_preferences=morning,night

GET /groups?name=test&time_preferences=afternoon

GET /groups
```

## How
- [x] Add new `scope` to `groups`, that will be used for searching by `name` and `subject_id`.
- [x] Update `index` action on `GroupsController` to support searching by `name` and `subject_id`, and filtering by own groups.
- [x] Sort response by `time_preference`.
- [x] Add request specs.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Endpoint GET groups/search?queryparams](https://trello.com/c/73145SRA/189-be-endpoint-get-groups-searchqueryparams)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Postman
<img width="1654" alt="Screenshot 2023-10-19 at 6 00 27 PM" src="https://github.com/wyeworks/finder/assets/62676004/6ca1845a-5d62-4b75-ae58-d1ab95081b85">

<img width="1650" alt="Screenshot 2023-10-19 at 5 38 16 PM" src="https://github.com/wyeworks/finder/assets/62676004/5313da35-dfce-4b20-9014-2b433aa351d1">

<img width="1651" alt="Screenshot 2023-10-21 at 7 41 08 PM" src="https://github.com/wyeworks/finder/assets/62676004/f5476bef-894b-414e-933b-9b602bc0fe7d">