### PR TITLE
[BE] PATCH /user old password before changing

### DIFF
--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -78,3 +78,5 @@ es:
             password:
               blank: "La contraseña no puede estar vacía"
               too_short: "La contraseña es demasiado corta. Debe tener al menos 8 caracteres"
+            current_password:
+              blank: "La contraseña actual no puede estar vacía."

--- a/api/config/locales/es.yml
+++ b/api/config/locales/es.yml
@@ -80,3 +80,4 @@ es:
               too_short: "La contraseña es demasiado corta. Debe tener al menos 8 caracteres"
             current_password:
               blank: "La contraseña actual no puede estar vacía."
+              invalid: "La contraseña actual es incorrecta."

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -138,6 +138,48 @@ RSpec.describe UsersController, type: :request do
         expect(json_response['errors']['name'][0]).to include('El nombre no puede ser vacío')
       end
     end
+    context 'with password change' do
+      let(:new_password) { 'ComplexPassword123!' }
+      let(:update_params) do
+        {
+          current_password: user.password,
+          password: new_password,
+          password_confirmation: new_password
+        }
+      end
+
+      it 'changes the user password successfully' do
+        user.reload
+        expect(user.valid_password?(new_password)).to be true
+      end
+    end
+
+    context 'with invalid current password' do
+      let(:new_password) { 'ComplexPassword123!' }
+      let(:invalid_current_password) { 'invalidpassword' }
+      let(:update_params) do
+        {
+          current_password: invalid_current_password,
+          password: new_password,
+          password_confirmation: new_password
+        }
+      end
+
+      it 'returns an error status' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not change the user password' do
+        user.reload
+        expect(user.valid_password?(user.password)).to be true
+        expect(user.valid_password?(new_password)).to be false
+      end
+
+      it 'returns JSON containing error message for invalid current password' do
+        json_response = response.parsed_body
+        expect(json_response['errors']['current_password'][0]).to eq('La validación falló y el record no es válido')
+      end
+    end
   end
 
   # Destroy

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -177,7 +177,7 @@ RSpec.describe UsersController, type: :request do
 
       it 'returns JSON containing error message for invalid current password' do
         json_response = response.parsed_body
-        expect(json_response['errors']['current_password'][0]).to eq('La validación falló y el record no es válido')
+        expect(json_response['errors']['current_password'][0]).to eq('La contraseña actual es incorrecta.')
       end
     end
   end


### PR DESCRIPTION
## What && Why
Para modificar la contraseña hay que enviar el valor de "current_password" para modificarla

## How
- [x] Update method
- [x] Translations
- [x] Tests

## Disclaimers / Extra Comments
La nueva contraseña puede ser la misma que la actual, intente cambiar esto, agregando un metodo en el modelo, pero se rompian todos los test. Al no poder arreglarlo y ya que no es un problema de seguridad, lo deje así. 

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] PATCH /user Old password before changing](https://trello.com/c/dlLetzxo/205-be-patch-user-old-password-before-changing)

## How to Review
- [ ] Review commit by commit recommended.
- [x] Review all at once recommended.

## Screenshots
**Contraseña actual incorrecta:**

![image](https://github.com/wyeworks/finder/assets/49001847/e202bf2b-eccd-48d1-a31e-c9a8d7a7d8a1)

**Contraseña actual correcta:**

![image](https://github.com/wyeworks/finder/assets/49001847/4e3aad70-2c61-415b-9206-76bb3b6cf5b3)

**Sin current password:**

![image](https://github.com/wyeworks/finder/assets/49001847/50f4396b-1270-4a3a-9ccb-dba037d5dd03)


