### PR TITLE
[FE] Social network links and https:// at the beginning

### DIFF
--- a/client/src/components/common/SocialNetworkButton.tsx
+++ b/client/src/components/common/SocialNetworkButton.tsx
@@ -13,11 +13,16 @@ type SocialNetworkButtonProps = {
   link: string;
 };
 
+function validateUrl(url: string) {
+  if (url.startsWith('https://')) return url;
+  else return `https://${url}`;
+}
+
 function SocialNetworkButton(props: SocialNetworkButtonProps) {
   return (
     <a
       data-testid={`${props.name}Button`}
-      href={props.link}
+      href={validateUrl(props.link)}
       className='m-2 h-6 w-6'
     >
       <div className={'flex items-center justify-center'}>{props.icon}</div>


### PR DESCRIPTION
## What && Why
When creating the social network button it now adds the `https://` at the beginning if it's not there already so that it redirects correctly

Ticket https://trello.com/c/8sN1Fvyk/245-fe-editar-perfil-validaci%C3%B3n-campo-redes-sociales