### PR TITLE
Remove same User validation for Show

### DIFF
--- a/api/app/controllers/users_controller.rb
+++ b/api/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
-  before_action :set_user, :validate_current_user
+  before_action :set_user
+  before_action :validate_current_user, except: :show
   before_action :handle_user_groups, only: :destroy
 
   def show

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe UsersController, type: :request do
   end
 
   # Show
-  # Show
   describe 'GET /users/:id' do
     let(:user) { create :user, :with_social_networks, :with_careers, :with_subjects }
 
@@ -45,22 +44,6 @@ RSpec.describe UsersController, type: :request do
 
         expect(json_response[0]['id']).to be_a(Integer)
         expect(json_response[0]['name']).to be_a(String)
-      end
-
-      context 'when trying to access another user data' do
-        let(:another_user) { create :user }
-        before do
-          get user_path(another_user), headers:
-        end
-
-        it 'returns http unauthorized' do
-          expect(response).to have_http_status(:unauthorized)
-        end
-
-        it 'returns a not authorized message' do
-          json_response = response.parsed_body
-          expect(json_response['errors']['user'][0]).to eq('No estás autorizado para realizar esta acción')
-        end
       end
     end
 
@@ -321,10 +304,11 @@ RSpec.describe UsersController, type: :request do
         end
       end
 
-      context 'when trying to access another user data' do
+      context 'when trying to delete another user' do
         let(:another_user) { create :user }
+
         before do
-          get user_path(another_user), headers:
+          delete user_path(another_user.id), headers:
         end
 
         it 'returns http unauthorized' do


### PR DESCRIPTION
## What && Why
Remove same user validation for `show` action on `UsersController`.
No longer needed since users will be able to access other users' profiles.

## How
- [x] Remove validation for `show`.
- [x] Update specs.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) No ticket.

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.