### PR TITLE
Remove Unnecessary Actions from UsersController

### DIFF
--- a/api/app/controllers/users_controller.rb
+++ b/api/app/controllers/users_controller.rb
@@ -38,22 +38,6 @@ class UsersController < ApplicationController
     end
   end
 
-  def careers
-    careers = @user.careers.map do |career|
-      CareerSerializer.new(career).serializable_hash[:data][:attributes]
-    end
-
-    render json: careers
-  end
-
-  def subjects
-    subjects = @user.subjects.map do |subject|
-      SubjectSerializer.new(subject).serializable_hash[:data][:attributes]
-    end
-
-    render json: subjects
-  end
-
   private
 
   def set_user

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -28,22 +28,14 @@ RSpec.describe UsersController, type: :request do
         expect(json_response['name']).to eq(user.name)
         expect(DateTime.parse(json_response['birth_date'])).to eq(user.birth_date)
         expect(json_response['social_networks']).to eq(user.social_networks)
-      end
 
-      it "returns JSON containing user's careers data" do
-        json_response = response.parsed_body['careers']
+        expect(json_response['careers'][0]['id']).to eq(user.careers.first.id)
+        expect(json_response['careers'][0]['code']).to eq(user.careers.first.code)
+        expect(json_response['careers'][0]['name']).to eq(user.careers.first.name)
 
-        expect(json_response[0]['id']).to be_a(Integer)
-        expect(json_response[0]['name']).to be_a(String)
-        expect(json_response[0]['code']).to be_a(String)
-      end
-
-      # Subjects
-      it "returns JSON containing user's subjects data" do
-        json_response = response.parsed_body['subjects']
-
-        expect(json_response[0]['id']).to be_a(Integer)
-        expect(json_response[0]['name']).to be_a(String)
+        expect(json_response['subjects'][0]['id']).to eq(user.subjects.first.id)
+        expect(json_response['subjects'][0]['code']).to eq(user.subjects.first.code)
+        expect(json_response['subjects'][0]['name']).to eq(user.subjects.first.name)
       end
     end
 
@@ -114,6 +106,14 @@ RSpec.describe UsersController, type: :request do
         expect(json_response['bio']).to eq(bio)
         expect(DateTime.parse(json_response['birth_date'])).to eq(birth_date)
         expect(json_response['social_networks']).to eq(social_networks.with_indifferent_access)
+
+        expect(json_response['careers'][0]['id']).to eq(career.id)
+        expect(json_response['careers'][0]['code']).to eq(career.code)
+        expect(json_response['careers'][0]['name']).to eq(career.name)
+
+        expect(json_response['subjects'][0]['id']).to eq(subject.id)
+        expect(json_response['subjects'][0]['code']).to eq(subject.code)
+        expect(json_response['subjects'][0]['name']).to eq(subject.name)
       end
     end
 
@@ -136,6 +136,7 @@ RSpec.describe UsersController, type: :request do
         expect(json_response['errors']['name'][0]).to include('El nombre no puede ser vacío')
       end
     end
+
     context 'with password change' do
       let(:new_password) { 'ComplexPassword123!' }
       let(:update_params) do


### PR DESCRIPTION
## What && Why
Remove unnecessary `careers` and `subjects` actions from `UsersController`.
They were inaccessible after #161 because routes were no longer there.

## How
- [x] Remove actions.
- [x] Update specs.

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots: coverage
#### Before
<img width="1754" alt="Screenshot 2023-10-24 at 5 42 36 PM" src="https://github.com/wyeworks/finder/assets/62676004/f4286dac-d063-4dff-9113-a4d6d95b2283">

#### After
<img width="1751" alt="Screenshot 2023-10-24 at 6 07 24 PM" src="https://github.com/wyeworks/finder/assets/62676004/84cf3781-1ddd-4629-889a-167e838ecc1c">