### PR TITLE
Fix issue when trying to create a new request after member left the group

### DIFF
--- a/api/spec/models/request_spec.rb
+++ b/api/spec/models/request_spec.rb
@@ -65,14 +65,14 @@ RSpec.describe Request, type: :model do
       end
     end
 
-    context 'when there is an existing pending or accepted request for the same user and group' do
+    context 'when there is an existing pending request for the same user and group' do
       let(:user) { create(:user) }
       let(:group) { create(:group) }
       let!(:existing_request) { create(:request, user:, group:) }
       let(:new_request) { build(:request, user:, group:) }
 
       it 'does not allow the creation of a new request' do
-        expected_error = 'Ya hay una solicitud pendiente o aceptada para este usuario y grupo'
+        expected_error = 'Ya hay una solicitud pendiente para este usuario y grupo'
         expect(new_request).not_to be_valid
         expect(new_request.errors[:general]).to include(expected_error)
       end

--- a/api/spec/requests/groups/requests_controller_spec.rb
+++ b/api/spec/requests/groups/requests_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'Groups::Requests', type: :request do
 
         it 'returns JSON containing error messages' do
           json_response = response.parsed_body
-          expected_error = 'Ya hay una solicitud pendiente o aceptada para este usuario y grupo'
+          expected_error = 'Ya hay una solicitud pendiente para este usuario y grupo'
           expect(json_response['errors']['general']).to include(expected_error)
         end
       end
@@ -220,7 +220,7 @@ RSpec.describe 'Groups::Requests', type: :request do
     end
   end
 
-  # Show group request
+  # Index
   describe 'GET /groups/:group_id/requests' do
     let(:user) { create(:user) }
     let(:group) { create(:group) }

--- a/api/spec/requests/users_controller_spec.rb
+++ b/api/spec/requests/users_controller_spec.rb
@@ -321,6 +321,24 @@ RSpec.describe UsersController, type: :request do
           expect(json_response['errors']['user'][0]).to eq('No estás autorizado para realizar esta acción')
         end
       end
+
+      context 'when user destruction fails' do
+        before do
+          allow_any_instance_of(User).to receive(:destroy).and_return(false)
+
+          delete user_path(user.id), headers:
+        end
+
+        it 'returns an unprocessable entity status' do
+          expect(response).to have_http_status(:unprocessable_entity)
+        end
+
+        it 'returns a JSON containing error messages' do
+          json_response = response.parsed_body
+
+          expect(json_response['message']).to eq('El usuario no pudo ser borrado correctamente')
+        end
+      end
     end
 
     context 'when user is not authenticated' do


### PR DESCRIPTION
## What && Why
Fix issue when trying to create a new request after member left the group.
Increase controllers coverage.

## How
- [x] Update `requests` validations.
- [x] Add missing tests. 

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE]: FIX: Requests al Eliminar del Grupo y salirme del grupo](https://trello.com/c/DUbdwhA5/299-be-fix-requests-al-eliminar-del-grupo-y-salirme-del-grupo)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Screenshots
#### Coverage
<img width="1263" alt="Screenshot 2023-10-24 at 10 49 40 PM" src="https://github.com/wyeworks/finder/assets/62676004/b4853e6c-0768-4101-b0eb-e0f304956926">