### PR TITLE
add time preferences if user is not member group

### DIFF
--- a/client/src/app/(protected)/groups/[id]/Content/Sessions/Sessions.tsx
+++ b/client/src/app/(protected)/groups/[id]/Content/Sessions/Sessions.tsx
@@ -194,8 +194,11 @@ export default function Sessions({ group }: SessionsProps) {
 
   if (!isMemberGroup) {
     return (
-      <div className='border border-solid p-10 text-center'>
-        Debes ser un miembro para ver las sesiones del grupo.
+      <div>
+        <div className='my-4 border border-solid bg-white p-10 text-center'>
+          Debes ser un miembro para ver las sesiones del grupo.
+        </div>
+        <TimePreferences group={group} />
       </div>
     );
   }


### PR DESCRIPTION
## What && Why
La tab de sesiones de un grupo no quede oculta del todo para no miembros de la app.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [Tab Sesiones - Mostrar Pref Horarias](https://trello.com/c/0J66cMPh)

## How to Review
- [ ] Review commit by commit recommended.
- [x] Review all at once recommended.

## Screenshots
![image](https://github.com/wyeworks/finder/assets/79933970/0572e773-7169-4f71-bdbc-8cc51b0802e5)
