### PR TITLE
[BE] Actualizar serializer Group - Retorne sessions

### DIFF
--- a/api/app/serializers/group_serializer.rb
+++ b/api/app/serializers/group_serializer.rb
@@ -12,6 +12,8 @@ class GroupSerializer
 
   belongs_to :subject
 
+  has_many :sessions
+
   attribute :subject_name do |group|
     group.subject.name
   end
@@ -31,6 +33,12 @@ class GroupSerializer
       end
     else
       []  # Return an empty array if the user isn't an admin.
+    end
+  end
+
+  attribute :sessions do |group|
+    group.sessions.map do |session|
+      SessionSerializer.new(session).serializable_hash[:data][:attributes]
     end
   end
 end

--- a/api/spec/factories/group.rb
+++ b/api/spec/factories/group.rb
@@ -11,5 +11,12 @@ FactoryBot.define do
         create_list(:member, 2, group:, role: 'participant')
       end
     end
+
+    trait :with_sessions do
+      with_members
+      after(:create) do |group|
+        create_list(:session, 3, group:)
+      end
+    end
   end
 end

--- a/api/spec/requests/groups_controller_spec.rb
+++ b/api/spec/requests/groups_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GroupsController, type: :request do
 
   # Index
   describe 'GET /groups' do
-    let(:groups) { create_list :group, 2 }
+    let(:groups) { create_list(:group, 2, :with_sessions) }
 
     before do
       get groups_path(groups), headers:
@@ -31,6 +31,14 @@ RSpec.describe GroupsController, type: :request do
         expect(json_response[0]['time_preferences']).to be_a(Hash)
         expect(json_response[0]['subject_id']).to be_a(Integer)
         expect(json_response[0]['subject_name']).to be_a(String)
+      end
+
+      it 'returns JSON containing sessions data for each group' do
+        json_response = response.parsed_body
+
+        expect(json_response[0]['sessions']).to be_a(Array)
+        expect(json_response[0]['sessions'][0]['id']).to be_a(Integer)
+        expect(json_response[0]['sessions'][0]['name']).to be_a(String)
       end
     end
 
@@ -100,14 +108,14 @@ RSpec.describe GroupsController, type: :request do
 
   # Show
   describe 'GET /groups/:id' do
-    let(:group) { create(:group) }
+    let(:group) { create(:group, :with_sessions) }
     let(:group_id) { group.id }
 
     before do
       get group_path(group_id), headers:
     end
 
-    context 'when user is not authenticated' do
+    context 'when user is authenticated' do
       context 'when the group exists' do
         it 'returns a successful response' do
           expect(response).to be_successful
@@ -124,6 +132,14 @@ RSpec.describe GroupsController, type: :request do
           expect(json_response['subject_id']).to eq(group.subject_id)
           expect(json_response['subject_name']).to eq(group.subject.name)
         end
+      end
+
+      it 'returns JSON containing sessions data for the group' do
+        json_response = response.parsed_body
+
+        expect(json_response['sessions']).to be_a(Array)
+        expect(json_response['sessions'][0]['id']).to be_a(Integer)
+        expect(json_response['sessions'][0]['name']).to be_a(String)
       end
 
       context 'when the group does not exist' do


### PR DESCRIPTION
## What && Why
Se actualiza `GroupSerializer` para incluir las sessiones.

## How
- [x] Serializer actualizado
- [x] Test actualizados


## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Actualizar serializer Group - Retorne sessions](https://trello.com/c/YkoLvpOH/291-be-actualizar-serializer-group-retorne-sessions)

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Output
![image](https://github.com/wyeworks/finder/assets/77336573/e559ff83-2450-492e-88ce-dea3f02f1071)

## Screenshots
![image](https://github.com/wyeworks/finder/assets/77336573/57d34f7d-1f74-4393-b8f1-80dd18b1def5)
![image](https://github.com/wyeworks/finder/assets/77336573/54b7cca4-6f13-4986-957d-e657dcdd2598)

