### PR TITLE
[BE] Sesiones Estudio - Agregar asistencias en GET session

### DIFF
--- a/api/app/serializers/session_serializer.rb
+++ b/api/app/serializers/session_serializer.rb
@@ -8,6 +8,19 @@ class SessionSerializer
              :meeting_link,
              :start_time,
              :end_time,
-             :group_id,
-             :attendances
+             :group_id
+
+  attribute :attendances do |session|
+    session.attendances.map do |attendance|
+      {
+        id: attendance.id,
+        session_id: attendance.session_id,
+        status: attendance.status,
+        created_at: attendance.created_at,
+        updated_at: attendance.updated_at,
+        member_id: attendance.member_id,
+        member_name: attendance.member.user.name
+      }
+    end
+  end
 end

--- a/api/spec/requests/sessions_controller_spec.rb
+++ b/api/spec/requests/sessions_controller_spec.rb
@@ -44,7 +44,8 @@ RSpec.describe SessionsController, type: :request do
                 'status' => attendance.status,
                 'created_at' => attendance.created_at.utc.iso8601(3),
                 'updated_at' => attendance.updated_at.utc.iso8601(3),
-                'member_id' => attendance.member_id
+                'member_id' => attendance.member_id,
+                'member_name' => user.name
               }
             end
 


### PR DESCRIPTION
## What && Why
Se actualiza `SessionSerializer` para devolver el nombre de los participantes en la lista de `Attendences`

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Sesiones Estudio - Agregar asistencias en GET session](https://trello.com/c/jT2PNpWj/301-be-sesiones-estudio-agregar-asistencias-en-get-session)

## How to Review
- [ ] Review commit by commit recommended.
- [ ] Review all at once recommended.

## Output
![image](https://github.com/wyeworks/finder/assets/77336573/df2d7a83-4385-4e31-808e-b6b9abb84408)

## Screenshots
![image](https://github.com/wyeworks/finder/assets/77336573/d463ef87-508c-465a-8af2-2ab7a007e8a1)
