### PR TITLE
Added endpoint and mail to reset password

### DIFF
--- a/api/app/controllers/users/passwords_controller.rb
+++ b/api/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,52 @@
+module Users
+  class PasswordsController < Devise::PasswordsController
+    respond_to :json
+
+    # Skip authentication, user might not know his password
+    skip_before_action :authenticate_user!, only: %i[create update]
+
+    def create
+      self.resource = resource_class.send_reset_password_instructions(resource_params)
+
+      if successfully_sent?(resource)
+        Rails.logger.info "Reset password instructions sent to '#{resource.email}' successfully."
+        render json: { message: "Instrucciones enviadas correctamente a #{resource.email}." },
+               status: :ok
+      else
+        Rails.logger.info "Failed to send instructions to '#{resource.email}' due to: #{resource.errors.full_messages}"
+        render json: {
+          message: 'No se pudieron enviar las instrucciones para reestablecer la contraseña.',
+          errors: resource.errors.messages
+        }, status: :unprocessable_entity
+      end
+    end
+
+    def update
+      user_by_email = User.find_by(email: resource_params[:email])
+
+      if user_by_email && Devise.token_generator.digest(
+        User, :reset_password_token, resource_params[:reset_password_token]
+      ) == user_by_email.reset_password_token
+        self.resource = resource_class.reset_password_by_token(resource_params)
+
+        if resource.errors.empty?
+          Rails.logger.info "Password for user with email '#{resource.email}' was reset successfully."
+          render json: { message: 'Contraseña reestablecida correctamente.' }, status: :ok
+        else
+          Rails.logger.info 'Failed to reset password for user with email ' \
+                            "'#{resource.email}' due to the following errors: #{resource.errors.full_messages}"
+          render json: {
+            message: 'No se pudo reestablecer la contraseña.',
+            errors: resource.errors.messages
+          }, status: :unprocessable_entity
+        end
+      else
+        Rails.logger.info 'Failed to reset password due to mismatched email or token.'
+        render json: {
+          message: 'No se pudo reestablecer la contraseña debido a un correo electrónico o token no coincidentes.',
+          errors: { email: ['El correo electrónico proporcionado no coincide con el token.'] }
+        }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/api/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/api/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,9 @@
+<p>Hola <%= @resource.name %>!</p>
+
+<p>Recibimos una solicitud para reestablecer tu contraseña. Si no hiciste esta solicitud, puedes ignorar este correo. Si deseas reestablecer tu contraseña, sigue las instrucciones a continuación:</p>
+
+<p>1. Copia el siguiente token: <strong><%= @token %></strong></p>
+<p>2. Ve a la página de reestablecimiento de contraseña: <%= link_to 'Reestablecer Contraseña', Rails.configuration.client_base_url + '/recover_password' %></p>
+<p>3. Ingresa tu dirección de correo electrónico, pega el token que copiaste y establece tu nueva contraseña.</p>
+
+<p>Este token será válido por 6 horas.</p>

--- a/api/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/api/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -3,7 +3,7 @@
 <p>Recibimos una solicitud para reestablecer tu contraseña. Si no hiciste esta solicitud, puedes ignorar este correo. Si deseas reestablecer tu contraseña, sigue las instrucciones a continuación:</p>
 
 <p>1. Copia el siguiente token: <strong><%= @token %></strong></p>
-<p>2. Ve a la página de reestablecimiento de contraseña: <%= link_to 'Reestablecer Contraseña', Rails.configuration.client_base_url + '/recover_password' %></p>
+<p>2. Ve a la página de reestablecimiento de contraseña: <%= link_to 'Reestablecer Contraseña', Rails.configuration.client_base_url + '/recover-password' %></p>
 <p>3. Ingresa tu dirección de correo electrónico, pega el token que copiaste y establece tu nueva contraseña.</p>
 
 <p>Este token será válido por 6 horas.</p>

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -4,12 +4,14 @@ Rails.application.routes.draw do
   devise_for :users, path_names: {
     sign_in: 'login',
     sign_out: 'logout',
-    registration: 'signup'
+    registration: 'signup',
+    password: 'forgot_password'
   },
   controllers: {
     sessions: 'users/sessions',
     registrations: 'users/registrations',
-    confirmations: 'users/confirmations'
+    confirmations: 'users/confirmations',
+    passwords: 'users/passwords'
   }
 
   resources :careers, only: :index

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -5,7 +5,6 @@ Rails.application.routes.draw do
     sign_in: 'login',
     sign_out: 'logout',
     registration: 'signup',
-    password: 'forgot_password'
   },
   controllers: {
     sessions: 'users/sessions',

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -82,7 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_21_091351) do
     t.string "name", null: false
     t.text "description"
     t.string "location"
-    t.string "meeting_link"
+    t.string "meeting_link", null: false
     t.datetime "start_time", null: false
     t.datetime "end_time", null: false
     t.bigint "group_id", null: false

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -82,7 +82,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_21_091351) do
     t.string "name", null: false
     t.text "description"
     t.string "location"
-    t.string "meeting_link", null: false
+    t.string "meeting_link"
     t.datetime "start_time", null: false
     t.datetime "end_time", null: false
     t.bigint "group_id", null: false

--- a/api/spec/requests/users/passwords_controller_spec.rb
+++ b/api/spec/requests/users/passwords_controller_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+
+RSpec.describe Users::PasswordsController, type: :request do
+  describe 'POST #create' do
+    let(:user) { create(:user) }
+
+    context 'when the email is valid' do
+      before do
+        post user_password_path, params: { user: { email: user.email } }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'sends reset password instructions to the user' do
+        expect(user.reload.reset_password_token).not_to be_nil
+        expect(user.reload.reset_password_sent_at).not_to be_nil
+      end
+    end
+
+    context 'when the email is invalid' do
+      before do
+        post user_password_path, params: { user: { email: 'invalid_email@example.com' } }
+      end
+
+      it 'returns http unprocessable_entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not send reset password instructions' do
+        expect(user.reload.reset_password_token).to be_nil
+        expect(user.reload.reset_password_sent_at).to be_nil
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    let(:user) { create(:user) }
+    let(:new_password) { 'NewPassword123!' }
+
+    context 'when the reset password token is valid' do
+      before do
+        raw_token, hashed_token = Devise.token_generator.generate(User, :reset_password_token)
+        user.reset_password_token = hashed_token
+        user.reset_password_sent_at = Time.now.utc
+        user.save!
+
+        put user_password_path, params: {
+          user: {
+            reset_password_token: raw_token,
+            password: new_password,
+            password_confirmation: new_password,
+            email: user.email
+          }
+        }
+      end
+
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
+      end
+
+      it 'updates the user password' do
+        expect(user.reload.valid_password?(new_password)).to be_truthy
+      end
+    end
+
+    context 'when the reset password token is invalid' do
+      before do
+        put user_password_path, params: {
+          user: {
+            reset_password_token: 'invalid_token',
+            password: new_password,
+            password_confirmation: new_password
+          }
+        }
+      end
+
+      it 'returns http unprocessable_entity' do
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it 'does not update the user password' do
+        expect(user.reload.valid_password?(new_password)).to be_falsy
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What && Why
add explanation here

## How
- [x] Método para crear la solicitud y enviar token
- [x] Método para actualizar la contraseña
- [x] Tests

## Disclaimers / Extra Comments
Se redirige a ` Rails.configuration.client_base_url + '/recover_password'`, esto puede ser que se tenga que ajustar- 

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Restablecer contraseña Usuario](https://trello.com/c/Vh3HH59z/82-be-restablecer-contrase%C3%B1a-usuario)

## How to Review
- [x] Review all at once recommended.

## Output
**Se agregan dos endpoints**

`POST   /users/forgot_password`
`PUT   /users/forgot_password`
## Screenshots
**post to /forgot_password**

![image](https://github.com/wyeworks/finder/assets/49001847/e47ae7ab-405d-4aa3-9df2-35a8c99a3edf)

**put a /forgot_password si no se adjunta mail, o token incorrecto**

![image](https://github.com/wyeworks/finder/assets/49001847/0c227cf7-c6bd-495d-9f7c-62d5dea182d1)

**put con datos correctos**

![image](https://github.com/wyeworks/finder/assets/49001847/f11a32cb-f19a-45a2-9061-2245a6173504)

