### PR TITLE
Always return 200 when reseting password

### DIFF
--- a/api/app/controllers/users/passwords_controller.rb
+++ b/api/app/controllers/users/passwords_controller.rb
@@ -8,38 +8,19 @@ module Users
     def create
       user = User.find_by(email: resource_params[:email])
 
-      if user
-        # rate limit
-        if cooldown_passed?(user.reset_password_sent_at)
-          self.resource = resource_class.send_reset_password_instructions(resource_params)
-
-          if successfully_sent?(resource)
-            user.update(reset_password_sent_at: Time.current)
-
-            Rails.logger.info "Reset password instructions sent to '#{resource.email}' successfully."
-            render json: { message: "Instrucciones enviadas correctamente a #{resource.email}." },
-                   status: :ok
-          else
-            Rails.logger.info 'Failed to send instructions to ' \
-                              "'#{resource.email}' due to: #{resource.errors.full_messages}"
-            render json: {
-              message: 'No se pudieron enviar las instrucciones para reestablecer la contraseña.',
-              errors: resource.errors.messages
-            }, status: :unprocessable_entity
-          end
-        else
-          # si hay una solicitud que achique
-          render json: {
-            message: 'La solicitud de reestablecimiento de contraseña ha sido enviada recientemente. ' \
-                     'Por favor, espera un poco antes de intentar de nuevo.'
-          }, status: :too_many_requests
-        end
-      else
-        render json: {
-          message: 'No se encontró un usuario con ese correo electrónico.',
-          errors: { email: ['El correo electrónico no es válido o no existe.'] }
-        }, status: :unprocessable_entity
+      # Only attempt to send instructions if the user exists.
+      if user && cooldown_passed?(user.reset_password_sent_at)
+        self.resource = resource_class.send_reset_password_instructions(resource_params)
+        user.update(reset_password_sent_at: Time.current) if successfully_sent?(resource)
       end
+
+      # Log an attempt to request password reset instructions.
+      Rails.logger.info "Attempted to send reset password instructions to '#{resource_params[:email]}'."
+
+      # Always return a success message.
+      render json: { message: 'Si tu correo electrónico existe en nuestra base de datos, ' \
+                              'recibirás un correo con instrucciones para reestablecer tu contraseña.' },
+             status: :ok
     end
 
     def update

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -93,7 +93,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_04_193818) do
     t.string "name", null: false
     t.text "description"
     t.string "location"
-    t.string "meeting_link", null: false
+    t.string "meeting_link"
     t.datetime "start_time", null: false
     t.datetime "end_time", null: false
     t.bigint "group_id", null: false

--- a/api/spec/requests/users/passwords_controller_spec.rb
+++ b/api/spec/requests/users/passwords_controller_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Users::PasswordsController, type: :request do
         post user_password_path, params: { user: { email: 'invalid_email@example.com' } }
       end
 
-      it 'returns http unprocessable_entity' do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
       end
 
       it 'does not send reset password instructions' do
@@ -95,8 +95,8 @@ RSpec.describe Users::PasswordsController, type: :request do
         post user_password_path, params: { user: { email: user.email } }
       end
 
-      it 'returns http too_many_requests' do
-        expect(response).to have_http_status(:too_many_requests)
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
       end
 
       it 'does not send another reset password instructions' do
@@ -151,19 +151,23 @@ RSpec.describe Users::PasswordsController, type: :request do
         post user_password_path, params: { user: { email: user.email } }
       end
 
-      it 'returns http unprocessable_entity' do
-        expect(response).to have_http_status(:unprocessable_entity)
+      it 'returns http success' do
+        expect(response).to have_http_status(:ok)
       end
 
-      it 'logs the failure' do
-        expect(Rails.logger).to have_received(:info).with(/Failed to send instructions/)
+      # Update this test to reflect the new logging behavior
+      it 'logs the attempt' do
+        expect(Rails.logger).to have_received(:info).with(/Attempted to send reset password instructions to/)
       end
 
-      it 'renders the error message in the response' do
+      # Update this test to expect the new success message
+      it 'renders a generic success message in the response' do
         expect(response.parsed_body['message']).to eq(
-          'No se pudieron enviar las instrucciones para reestablecer la contraseña.'
+          'Si tu correo electrónico existe en nuestra base de datos, ' \
+          'recibirás un correo con instrucciones para reestablecer tu contraseña.'
         )
-        expect(response.parsed_body['errors']).to include('base' => ['Error message'])
+        # Since you're always returning a success, you should not include errors in the response
+        expect(response.parsed_body).not_to have_key('errors')
       end
     end
   end


### PR DESCRIPTION
## What && Why
Always return 200 for security reasons, the message is always the same, even if there is a cooldown. 

## Output
![image](https://github.com/wyeworks/finder/assets/49001847/00541e59-c17a-4832-90c1-1441a9246d6f)

## Screenshots

**POST to unexisting mail**
![image](https://github.com/wyeworks/finder/assets/49001847/4ff3fed5-be00-45c1-b581-2924736e0644)

