### PR TITLE
Fix sessions callback for when non-admin creator tries to update a session

### DIFF
--- a/api/app/controllers/concerns/group_authorizable.rb
+++ b/api/app/controllers/concerns/group_authorizable.rb
@@ -27,7 +27,7 @@ module GroupAuthorizable
 
   def authorize_creator_or_group_admin!
     is_admin = @session.group.admin?(current_user)
-    is_creator = @session.creator == current_user
+    is_creator = @session.creator.user == current_user
 
     return if is_admin || is_creator
 

--- a/api/spec/requests/sessions_controller_spec.rb
+++ b/api/spec/requests/sessions_controller_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe SessionsController, type: :request do
   # Update
   describe 'PATCH /sessions/:id' do
     let(:group) { create :group }
-    let(:creator_member) { create(:member, user:, group:) }
+    let(:creator_member) { create(:member, user:, group:, role: 'participant') }
     let(:session) { create :session, group:, creator: creator_member }
     let(:session_params) do
       {


### PR DESCRIPTION
## What && Why
Fix sessions callback for when non-admin creator tries to update a session.
It was only working for groups admins.

## How
- [x] Update callback.
- [x] Contemplate scenario with tests.

## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) No ticket.

## How to Review
- [x] Review commit by commit recommended.
- [ ] Review all at once recommended.