### PR TITLE
changes on mail link to recover password

### DIFF
--- a/api/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/api/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -3,8 +3,7 @@
 <p>Recibimos una solicitud para reestablecer tu contraseña. Si no hiciste esta solicitud, puedes ignorar este correo. Si deseas reestablecer tu contraseña, sigue las instrucciones a continuación:</p>
 
 <p>1. Copia el siguiente código de verificación: <strong><%= @token %></strong></p>
-<p>2. Ve a la página de reestablecimiento de contraseña copiando y pegando la siguiente dirección en tu navegador:</p>
-<p><%= Rails.configuration.client_base_url + 'recover-password' %></p>
+<p>2. Ve a la página de reestablecimiento de contraseña: https://finder-git-develop-frodo2412.vercel.app/recover-password <%= link_to 'Reestablecer Contraseña', Rails.configuration.client_base_url + '/recover-password' %></p>
 <p>3. Ingresa tu dirección de correo electrónico, pega el token que copiaste y establece tu nueva contraseña.</p>
 
 <p>Este token será válido por 6 horas.</p>

--- a/api/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/api/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -3,7 +3,8 @@
 <p>Recibimos una solicitud para reestablecer tu contraseña. Si no hiciste esta solicitud, puedes ignorar este correo. Si deseas reestablecer tu contraseña, sigue las instrucciones a continuación:</p>
 
 <p>1. Copia el siguiente código de verificación: <strong><%= @token %></strong></p>
-<p>2. Ve a la página de reestablecimiento de contraseña: <%= link_to 'Reestablecer Contraseña', Rails.configuration.client_base_url + '/recover-password' %></p>
+<p>2. Ve a la página de reestablecimiento de contraseña copiando y pegando la siguiente dirección en tu navegador:</p>
+<p><%= Rails.configuration.client_base_url + 'recover-password' %></p>
 <p>3. Ingresa tu dirección de correo electrónico, pega el token que copiaste y establece tu nueva contraseña.</p>
 
 <p>Este token será válido por 6 horas.</p>


### PR DESCRIPTION
## What && Why
Se agrega el link en el cuerpo del correo.



## Disclaimers / Extra Comments
se modifica la ruta ya que quedaba `//recover-password`
## Links
- ![](https://github.trello.services/images/mini-trello-icon.png) [[BE] Reestablecer contraseña - Link en mail](https://trello.com/c/9EXPjYvz/356-be-reestablecer-contrase%C3%B1a-link-en-mail)
